### PR TITLE
Make tag text color readable for dark themes

### DIFF
--- a/flavours/catppuccin-frappe.css
+++ b/flavours/catppuccin-frappe.css
@@ -8,6 +8,7 @@
   --catppuccin-base: #303446;
   --catppuccin-surface0: #414559;
   --catppuccin-text: #c6d0f5;
+  --catppuccin-text-dark: #5b6078;
   --catppuccin-surface2: #626880;
   --catppuccin-teal: #81c8be;
   --catppuccin-green: #a6d189;
@@ -130,7 +131,7 @@
 
 #app.theme-default.is-dark .tag {
   background-color: var(--catppuccin-pink);
-  color: var(--catppuccin-text);
+  color: var(--catppuccin-text-dark);
 }
 
 #app.theme-default.is-dark .status.unknown::before {

--- a/flavours/catppuccin-frappe.css
+++ b/flavours/catppuccin-frappe.css
@@ -8,7 +8,6 @@
   --catppuccin-base: #303446;
   --catppuccin-surface0: #414559;
   --catppuccin-text: #c6d0f5;
-  --catppuccin-text-dark: #5b6078;
   --catppuccin-surface2: #626880;
   --catppuccin-teal: #81c8be;
   --catppuccin-green: #a6d189;
@@ -17,6 +16,7 @@
   --catppuccin-mauve: #ca9ee6;
   --catppuccin-red: #e78284;
   --catppuccin-yellow: #e5c890;
+  --catppuccin-text-dark: var(--catppuccin-surface2);
 
   --highlight-primary: transparent;
   --highlight-secondary: var(--catppuccin-surface0);

--- a/flavours/catppuccin-macchiato.css
+++ b/flavours/catppuccin-macchiato.css
@@ -8,7 +8,6 @@
   --catppuccin-base: #24273a;
   --catppuccin-surface0: #363a4f;
   --catppuccin-text: #cad3f5;
-  --catppuccin-text-dark: #5b6078;
   --catppuccin-surface2: #5b6078;
   --catppuccin-teal: #8bd5ca;
   --catppuccin-green: #a6da95;
@@ -17,6 +16,7 @@
   --catppuccin-mauve: #c6a0f6;
   --catppuccin-red: #ed8796;
   --catppuccin-yellow: #eed49f;
+  --catppuccin-text-dark: var(--catppuccin-surface2);
 
   --highlight-primary: transparent;
   --highlight-secondary: var(--catppuccin-surface0);

--- a/flavours/catppuccin-macchiato.css
+++ b/flavours/catppuccin-macchiato.css
@@ -8,6 +8,7 @@
   --catppuccin-base: #24273a;
   --catppuccin-surface0: #363a4f;
   --catppuccin-text: #cad3f5;
+  --catppuccin-text-dark: #5b6078;
   --catppuccin-surface2: #5b6078;
   --catppuccin-teal: #8bd5ca;
   --catppuccin-green: #a6da95;
@@ -130,7 +131,7 @@
 
 #app.theme-default.is-dark .tag {
   background-color: var(--catppuccin-pink);
-  color: var(--catppuccin-text);
+  color: var(--catppuccin-text-dark);
 }
 
 #app.theme-default.is-dark .status.unknown::before {

--- a/flavours/catppuccin-mocha.css
+++ b/flavours/catppuccin-mocha.css
@@ -8,7 +8,6 @@
   --catppuccin-base: #1e1e2e;
   --catppuccin-surface0: #313244;
   --catppuccin-text: #cdd6f4;
-  --catppuccin-text-dark: #5b6078;
   --catppuccin-surface2: #585b70;
   --catppuccin-teal: #94e2d5;
   --catppuccin-green: #a6e3a1;
@@ -17,6 +16,7 @@
   --catppuccin-mauve: #cba6f7;
   --catppuccin-red: #f38ba8;
   --catppuccin-yellow: #f9e2af;
+  --catppuccin-text-dark: var(--catppuccin-surface2);
 
   --highlight-primary: transparent;
   --highlight-secondary: var(--catppuccin-surface0);

--- a/flavours/catppuccin-mocha.css
+++ b/flavours/catppuccin-mocha.css
@@ -8,6 +8,7 @@
   --catppuccin-base: #1e1e2e;
   --catppuccin-surface0: #313244;
   --catppuccin-text: #cdd6f4;
+  --catppuccin-text-dark: #5b6078;
   --catppuccin-surface2: #585b70;
   --catppuccin-teal: #94e2d5;
   --catppuccin-green: #a6e3a1;
@@ -130,7 +131,7 @@
 
 #app.theme-default.is-dark .tag {
   background-color: var(--catppuccin-pink);
-  color: var(--catppuccin-text);
+  color: var(--catppuccin-text-dark);
 }
 
 #app.theme-default.is-dark .status.unknown::before {


### PR DESCRIPTION
Original Tag Text Color (unreadable)
<img width="306" alt="Screenshot 2023-10-19 at 2 49 03 PM" src="https://github.com/mrpbennett/catppucin-homer/assets/5900005/913fb825-525f-43e3-9e64-2faaeda8ee85">
Updated Tag Text Color
<img width="306" alt="Screenshot 2023-10-19 at 2 49 17 PM" src="https://github.com/mrpbennett/catppucin-homer/assets/5900005/f6cda32a-cebb-4e78-b174-47090b502547">
Update was made for all the dark themes.
