### PR TITLE
Fix card:hover to correctly apply light/dark theme

### DIFF
--- a/flavours/catppuccin-frappe.css
+++ b/flavours/catppuccin-frappe.css
@@ -7,8 +7,9 @@
 #app.theme-default.is-dark {
   --catppuccin-base: #303446;
   --catppuccin-surface0: #414559;
-  --catppuccin-text: #c6d0f5;
+  --catppuccin-surface1: #51576d;
   --catppuccin-surface2: #626880;
+  --catppuccin-text: #c6d0f5;
   --catppuccin-teal: #81c8be;
   --catppuccin-green: #a6d189;
   --catppuccin-peach: #ef9f76;
@@ -152,8 +153,8 @@
   box-shadow: 0 0 5px 1px var(--catppuccin-green);
 }
 
-body #app .card:hover {
-  background-color: #51576d; /* Surface1 */
+#app.theme-default.is-dark .card:hover {
+  background-color: var(--catppuccin-surface1);
 }
 
 /* Footer */

--- a/flavours/catppuccin-latte.css
+++ b/flavours/catppuccin-latte.css
@@ -7,8 +7,9 @@
 #app.theme-default.is-light {
   --catppuccin-base: #eff1f5;
   --catppuccin-surface0: #ccd0da;
-  --catppuccin-text: #4c4f69;
+  --catppuccin-surface1: #bcc0cc;
   --catppuccin-surface2: #acb0be;
+  --catppuccin-text: #4c4f69;
   --catppuccin-teal: #179299;
   --catppuccin-green: #40a02b;
   --catppuccin-peach: #fe640b;
@@ -151,8 +152,8 @@
   box-shadow: 0 0 5px 1px var(--catppuccin-green);
 }
 
-body #app .card:hover {
-  background-color: #bcc0cc; /* Surface1 */
+#app.theme-default.is-light .card:hover {
+  background-color: var(--catppuccin-surface1);
 }
 
 /* Footer */

--- a/flavours/catppuccin-macchiato.css
+++ b/flavours/catppuccin-macchiato.css
@@ -7,8 +7,9 @@
 #app.theme-default.is-dark {
   --catppuccin-base: #24273a;
   --catppuccin-surface0: #363a4f;
-  --catppuccin-text: #cad3f5;
+  --catppuccin-surface1: #494d64;
   --catppuccin-surface2: #5b6078;
+  --catppuccin-text: #cad3f5;
   --catppuccin-teal: #8bd5ca;
   --catppuccin-green: #a6da95;
   --catppuccin-peach: #f5a97f;
@@ -152,8 +153,8 @@
   box-shadow: 0 0 5px 1px var(--catppuccin-green);
 }
 
-body #app .card:hover {
-  background-color: #494d64; /* Surface1 */
+#app.theme-default.is-dark .card:hover {
+  background-color: var(--catppuccin-surface1);
 }
 
 /* Footer */

--- a/flavours/catppuccin-mocha.css
+++ b/flavours/catppuccin-mocha.css
@@ -7,8 +7,9 @@
 #app.theme-default.is-dark {
   --catppuccin-base: #1e1e2e;
   --catppuccin-surface0: #313244;
-  --catppuccin-text: #cdd6f4;
+  --catppuccin-surface1: #45475a;
   --catppuccin-surface2: #585b70;
+  --catppuccin-text: #cdd6f4;
   --catppuccin-teal: #94e2d5;
   --catppuccin-green: #a6e3a1;
   --catppuccin-peach: #fab387;
@@ -152,8 +153,8 @@
   box-shadow: 0 0 5px 1px var(--catppuccin-green);
 }
 
-body #app .card:hover {
-  background-color: #45475a; /* Surface1 */
+#app.theme-default.is-dark .card:hover {
+  background-color: var(--catppuccin-surface1);
 }
 
 /* Footer */


### PR DESCRIPTION
The :hover style for cards was not tagged properly with the is-light or is-dark attributes, meaning importing both Latte and a dark theme resulted in the hover state using whichever style was imported last.

This PR updates the selector for the card:hover style in each flavor to apply only in the respective light/dark mode. It also promotes the color used to a variable to match the `surface0`/`surface2` variables and to keep all color definitions centralized.