### PR TITLE
Link directly to background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,8 +412,6 @@ defaults:
 
 - Copy the file of your chosen flavour from [`flavours`](./flavours) over to
   `www/assets/...`
-- Copy [`romb.png`](./assets/images/backgrounds/romb.png) to
-  `www/assets/images/romb.png`.
 - Put these lines into `www/assets/config.yml` and save the file:
 
 ```yaml

--- a/flavours/catppuccin-frappe.css
+++ b/flavours/catppuccin-frappe.css
@@ -38,7 +38,7 @@
 /* Comment the following section out if you want no header image. Also, set --highlight-primary to var(--catppuccin-surface0). */
 
 #app.theme-default.dark #bighead {
-  background-image: url('../assets/images/romb.png');
+  background-image: url('../assets/images/backgrounds/romb.png');
   background-size: cover;
   background-position: center;
 }

--- a/flavours/catppuccin-latte.css
+++ b/flavours/catppuccin-latte.css
@@ -37,7 +37,7 @@
 /* Comment the following section out if you want no header image. Also, set --highlight-primary to var(--catppuccin-surface0). */
 
 #app.theme-default.light #bighead {
-  background-image: url('../assets/images/romb.png');
+  background-image: url('../assets/images/backgrounds/romb.png');
   background-size: cover;
   background-position: center;
 }

--- a/flavours/catppuccin-macchiato.css
+++ b/flavours/catppuccin-macchiato.css
@@ -38,7 +38,7 @@
 /* Comment the following section out if you want no header image. Also, set --highlight-primary to var(--catppuccin-surface0). */
 
 #app.theme-default.dark #bighead {
-  background-image: url('../assets/images/romb.png');
+  background-image: url('../assets/images/backgrounds/romb.png');
   background-size: cover;
   background-position: center;
 }

--- a/flavours/catppuccin-mocha.css
+++ b/flavours/catppuccin-mocha.css
@@ -38,7 +38,7 @@
 /* Comment the following section out if you want no header image. Also, set --highlight-primary to var(--catppuccin-surface0). */
 
 #app.theme-default.dark #bighead {
-  background-image: url('../assets/images/romb.png');
+  background-image: url('../assets/images/backgrounds/romb.png');
   background-size: cover;
   background-position: center;
 }


### PR DESCRIPTION
This eliminates the need to copy the background to the parent folder when deploying (which simplifies using this theme directly in Kubernetes).

## Summary by Sourcery

Link directly to the background image in CSS files to eliminate the need for copying during deployment, simplifying the process, especially in Kubernetes environments.

Enhancements:
- Link directly to the background image in CSS files to simplify deployment.

Documentation:
- Remove the instruction to copy the background image in the README.