### PR TITLE
Never make group title icons transparent

### DIFF
--- a/flavours/catppuccin-frappe.css
+++ b/flavours/catppuccin-frappe.css
@@ -175,3 +175,7 @@ body #bighead .navbar a {
 body #app .title {
   font-family: 'Fira Code', monospace;
 }
+
+body #main-section h2 i {
+  color: var(--catppuccin-surface1);
+}

--- a/flavours/catppuccin-latte.css
+++ b/flavours/catppuccin-latte.css
@@ -174,3 +174,7 @@ body #bighead .navbar a {
 body #app .title {
   font-family: 'Fira Code', monospace;
 }
+
+body #main-section h2 i {
+  color: var(--catppuccin-surface1);
+}

--- a/flavours/catppuccin-macchiato.css
+++ b/flavours/catppuccin-macchiato.css
@@ -175,3 +175,7 @@ body #bighead .navbar a {
 body #app .title {
   font-family: 'Fira Code', monospace;
 }
+
+body #main-section h2 i {
+  color: var(--catppuccin-surface1);
+}

--- a/flavours/catppuccin-mocha.css
+++ b/flavours/catppuccin-mocha.css
@@ -175,3 +175,7 @@ body #bighead .navbar a {
 body #app .title {
   font-family: 'Fira Code', monospace;
 }
+
+body #main-section h2 i {
+  color: var(--catppuccin-surface1);
+}


### PR DESCRIPTION
This fixes #9, at least for the mocha flavour. I havent really tested the others that much.

EDIT: Im not a designer, so this is possibly not the correct fix. Maybe it should be teal instead?

## Summary by Sourcery

Bug Fixes:
- Fix the transparency of group title icons.